### PR TITLE
fixed the confirmation Dialog

### DIFF
--- a/lib/views/menu/menu_view.dart
+++ b/lib/views/menu/menu_view.dart
@@ -167,6 +167,7 @@ class MenuView extends StatelessWidget with GetItMixin {
 
   showConformationDialog(BuildContext context, String confirmationMessage,
       String actionDescription, Function action) {
+
     // set up the buttons
     Widget cancelButton = TextButton(
       child: const Text(
@@ -185,6 +186,7 @@ class MenuView extends StatelessWidget with GetItMixin {
           Text(actionDescription, style: const TextStyle(color: Colors.white)),
       onPressed: () {
         action();
+        Navigator.pop(context);
       },
     );
 


### PR DESCRIPTION
  Widget continueButton = ElevatedButton(
      style: ButtonStyle(
          backgroundColor:
              MaterialStateProperty.all<Color>(MyColors.redForDeleteButton)),
      child:
          Text(actionDescription, style: const TextStyle(color: Colors.white)),
      onPressed: () {
        action();
        Navigator.pop(context); <----- diese Zeile hat gefehlt
      },
    );