### PR TITLE
Chat title

### DIFF
--- a/lib/services/firestore_service.dart
+++ b/lib/services/firestore_service.dart
@@ -71,4 +71,9 @@ class FirestoreService {
       }
     });
   }
+
+  Future<void> updateChatTitle(String chatId,String title) async{
+    await db.collection('chats').doc(chatId).set(
+        {'title': title}, SetOptions(merge: true));
+  }
 }

--- a/lib/services/gpt_service.dart
+++ b/lib/services/gpt_service.dart
@@ -39,7 +39,6 @@ class GptService {
     return message;
   }
 
-
   void _addResponseToChat(String response) {
     messages.add(Messages(
       role: Role.assistant,
@@ -52,5 +51,19 @@ class GptService {
       role: Role.user,
       content: prompt,
     ));
+  }
+
+  Future<String> generateChatTitle() async {
+    var summaryMessage =
+        Messages(role:Role.user, content: "summerize the conversation in 3 words");
+    messages.add(summaryMessage);
+    final request = ChatCompleteText(
+      messages: messages,
+      maxToken: 10,
+      model: GptTurboChatModel(),
+    );
+    var message = await _handleRequest(request);
+    messages.remove(summaryMessage);
+    return message;
   }
 }

--- a/lib/views/chat/chat_viewmodel.dart
+++ b/lib/views/chat/chat_viewmodel.dart
@@ -24,12 +24,14 @@ class ChatViewmodel extends ChangeNotifier {
   }
 
   bool _isLoading = false;
+
   bool get isLoading => _isLoading;
 
   // to generate a random id for chat to set in db.
   // STATE of current Chat
   String _chatId = const Uuid().v1();
   List<MessageModel> _messages = [];
+
   List<MessageModel> get messages => _messages;
 
   // sets a new chatId and messages to empty -> for state, new chat.
@@ -41,7 +43,7 @@ class ChatViewmodel extends ChangeNotifier {
   }
 
   // to set the loading state for response, for the UI to show the progress indicator.
-  setLoadingState(bool loading){
+  setLoadingState(bool loading) {
     _isLoading = loading;
     notifyListeners();
   }
@@ -82,7 +84,7 @@ class ChatViewmodel extends ChangeNotifier {
   }
 
   sendMessage(String prompt) async {
-   setLoadingState(true);
+    setLoadingState(true);
 
     // in case of empty messages -> new chat, needs to be created in DB.
     if (_messages.isEmpty) {
@@ -98,6 +100,10 @@ class ChatViewmodel extends ChangeNotifier {
     MessageModel messageResponse = createNewMessageModel(response, false);
     _addMessageToChat(messageResponse);
     _addMessageToDB(messageResponse);
+
+    if (messages.length == 2 || messages.length == 4) {
+      generateChatTitle();
+    }
 
     setLoadingState(false);
   }
@@ -141,5 +147,10 @@ class ChatViewmodel extends ChangeNotifier {
   // to add message to DB
   _addMessageToDB(MessageModel message) {
     firestoreService.addMessage(message);
+  }
+
+  void generateChatTitle() async {
+    var title = await gptService.generateChatTitle();
+    firestoreService.updateChatTitle(_chatId, title);
   }
 }


### PR DESCRIPTION
Es gibt einen Bug beim Mapping von einem Chats in ChatViewModel:

- Wenn man einen neuen Chat erstellt, nachdem die App startet, dann gibt's kein Problem.

- Wenn man aber einen Chat erstellt, nachdem man schon einen Chat hatte, dann wird die Liste von Messages in GptService nicht aktualisiert (geleert). Das Problem ->  Der User hat in diesem Fall die Messages von zwei Chats als Kontext, welcher an GPT geschickt wird.

- Das gleiche Problem gibt es, wenn man einen alten Chat aufmacht, der von Datenbank geladen wurde. Die Nachrichten werden ins ChatViewModel gemappt und angezeigt, aber GptService hat keine Ahnung davon.

**Lösung**: 

> Wenn man einen neuen Chat erstellt -> gptService.messages = []

> Wenn man Chat wechelt -> mappe die Nachrichten, die ins ChatViewmodel kommen, auch in gptService.messages.  Achte dabei auf die Rolle des senders.


geschätzter Aufwand: 10-20 min